### PR TITLE
Add `fromURLToFolder` parameter to define target folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         pip uninstall -y "jupyterlab_open_url_parameter" jupyterlab
 
     - name: Upload extension packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v6
       with:
         name: extension-artifacts
         path: dist/jupyterlab_open_url_parameter*
@@ -60,7 +60,7 @@ jobs:
       with:
         python-version: '3.9'
         architecture: 'x64'
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v6
       with:
         name: extension-artifacts
     - name: Install and Test

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -20,7 +20,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: jupyterlab_open_url_parameter-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-lts-latest"
   tools:
-    python: "mambaforge-4.10"
+    python: "mambaforge-latest"
 
 conda:
   environment: docs/environment.yml

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Which will result in the following URL when JupyterLab is running locally:
 
 http://localhost:8888/lab?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/data/iris.csv&fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/notebooks/Lorenz.ipynb
 
-To place downloaded files in a specific destination, use `folder` in the URL.
+To place downloaded files in a specific destination, use `fromURLToFolder` in the URL.
 Missing directories are created automatically.
 
 For example:
 
-http://localhost:8888/lab?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab_apod/cffae6a4049af97436f0c19a0dae65a574f74390/src/index.ts&folder=step-05
+http://localhost:8888/lab?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab_apod/cffae6a4049af97436f0c19a0dae65a574f74390/src/index.ts&fromURLToFolder=step-05
 
-With multiple `fromURL` values, the same `folder` destination is used for all files.
+With multiple `fromURL` values, the same `fromURLToFolder` destination is used for all files.
 
 https://user-images.githubusercontent.com/591645/230422671-c12761e9-9b9f-4d23-ab66-344568c6b0a5.mp4
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Which will result in the following URL when JupyterLab is running locally:
 
 http://localhost:8888/lab?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/data/iris.csv&fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab-demo/master/notebooks/Lorenz.ipynb
 
+To place downloaded files in a specific destination, use `folder` in the URL.
+Missing directories are created automatically.
+
+For example:
+
+http://localhost:8888/lab?fromURL=https://raw.githubusercontent.com/jupyterlab/jupyterlab_apod/cffae6a4049af97436f0c19a0dae65a574f74390/src/index.ts&folder=step-05
+
+With multiple `fromURL` values, the same `folder` destination is used for all files.
+
 https://user-images.githubusercontent.com/591645/230422671-c12761e9-9b9f-4d23-ab66-344568c6b0a5.mp4
 
 ℹ️ This extension uses the command `filebrowser:open-url` available in JupyterLab by default.

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,6 @@ name: jupyterlab-open-url-parameter
 channels:
 - conda-forge
 dependencies:
-- pip
 - python=3.10
 - pydata-sphinx-theme
 - myst-parser

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,7 @@ name: jupyterlab-open-url-parameter
 channels:
 - conda-forge
 dependencies:
+- pip
 - python=3.10
 - pydata-sphinx-theme
 - myst-parser
@@ -9,3 +10,5 @@ dependencies:
 - nodejs=22
 - jupyterlite-core>=0.7.0,<0.8
 - jupyterlite-sphinx
+- pip:
+  - ..

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,14 +2,11 @@ name: jupyterlab-open-url-parameter
 channels:
 - conda-forge
 dependencies:
-- build
+- pip
 - python=3.10
-- mamba
 - pydata-sphinx-theme
 - myst-parser
-- jupyterlab>=3.5.0,<3.6
-- nodejs=18
-- jupyterlite>=0.1.0,<0.2
-- pip:
-  - jupyterlite-sphinx
-  - ..
+- jupyterlab>=4.0.0,<5
+- nodejs=22
+- jupyterlite-core>=0.7.0,<0.8
+- jupyterlite-sphinx

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,11 +90,23 @@ const plugin: JupyterFrontEndPlugin<void> = {
             );
           };
 
+          const isConflictError = (reason: any): boolean => {
+            const message = String(reason?.message ?? reason).toLowerCase();
+            return (
+              reason?.response?.status === 409 ||
+              message.includes('already exists')
+            );
+          };
+
           const contents =
             browser?.model.manager.services.contents ??
             app.serviceManager.contents;
+          const cleanupCreated = async (path: string): Promise<void> => {
+            await contents.delete(path).catch(() => undefined);
+          };
           let currentPath = basePath;
           for (const part of directory.split('/').filter(Boolean)) {
+            const parentPath = currentPath;
             currentPath = contents.resolvePath(currentPath, part);
             try {
               const model = await contents.get(currentPath, { content: false });
@@ -107,22 +119,24 @@ const plugin: JupyterFrontEndPlugin<void> = {
               if (!isNotFoundError(reason)) {
                 throw reason;
               }
+              const created = await contents.newUntitled({
+                path: parentPath,
+                type: 'directory'
+              });
+              if (created.path === currentPath) {
+                continue;
+              }
+
               try {
-                await contents.save(currentPath, {
-                  type: 'directory'
-                });
-              } catch (saveReason) {
-                const message = String(
-                  (saveReason as any)?.message ?? saveReason
-                ).toLowerCase();
-                if (
-                  (saveReason as any)?.response?.status === 409 ||
-                  message.includes('already exists')
-                ) {
-                  // Race with another creator, treat as success.
+                await contents.rename(created.path, currentPath);
+              } catch (renameReason) {
+                if (isConflictError(renameReason)) {
+                  await cleanupCreated(created.path);
                   continue;
                 }
-                throw saveReason;
+
+                await cleanupCreated(created.path);
+                throw renameReason;
               }
             }
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,19 +47,68 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
         const urlParams = new URLSearchParams(search);
         const paramName = 'fromURL';
+        const folderParamName = 'folder';
         const paths = urlParams.getAll(paramName);
-        if (!paths || paths.length === 0) {
+        if (paths.length === 0) {
           return;
         }
-        const urls = paths.map(path => decodeURIComponent(path));
+        const urls = paths;
+        const folder = urlParams.get(folderParamName) ?? '';
+        const normalizedFolder = folder ? PathExt.normalize(folder) : '';
+        const trimmedFolder =
+          normalizedFolder !== '/' && normalizedFolder.endsWith('/')
+            ? normalizedFolder.slice(0, -1)
+            : normalizedFolder;
+        const folderPath = PathExt.removeSlash(trimmedFolder);
+        const uploadDirectory = normalizedFolder
+          ? folderPath === '.'
+            ? ''
+            : folderPath
+          : '';
 
         // handle the route and remove the fromURL parameter
         const handleRoute = () => {
           const url = new URL(URLExt.join(PageConfig.getBaseUrl(), request));
-          // only remove the fromURL parameter
+          // only remove parameters handled by the extension
           url.searchParams.delete(paramName);
+          url.searchParams.delete(folderParamName);
           const { pathname, search } = url;
           router.navigate(`${pathname}${search}`, { skipRouting: true });
+        };
+
+        const ensureDirectory = async (directory: string): Promise<void> => {
+          if (!directory) {
+            return;
+          }
+
+          const contents = app.serviceManager.contents;
+          let currentPath = '';
+          for (const part of directory.split('/').filter(Boolean)) {
+            currentPath = currentPath ? PathExt.join(currentPath, part) : part;
+            try {
+              const model = await contents.get(currentPath, { content: false });
+              if (model.type !== 'directory') {
+                throw new Error(
+                  trans.__('Path is not a directory: %1', currentPath)
+                );
+              }
+            } catch (reason) {
+              const error = reason as any;
+              if (error?.response?.status !== 404) {
+                throw reason;
+              }
+              try {
+                await contents.save(currentPath, {
+                  type: 'directory'
+                });
+              } catch (saveReason) {
+                const saveError = saveReason as any;
+                if (saveError?.response?.status !== 409) {
+                  throw saveReason;
+                }
+              }
+            }
+          }
         };
 
         // fetch the file from the URL and open it with the docmanager
@@ -84,11 +133,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
           try {
             // FIXME: handle Content-Disposition: https://github.com/jupyterlab/jupyterlab/issues/11531
             const name = PathExt.basename(url);
-            const file = new File([blob], name, { type });
-            const model = await browser?.model.upload(file);
+            const model = await browser?.model.upload(
+              new File([blob], name, { type })
+            );
+
             if (!model) {
               return;
             }
+
             return commands.execute('docmanager:open', {
               path: model.path,
               options: {
@@ -103,17 +155,37 @@ const plugin: JupyterFrontEndPlugin<void> = {
           }
         };
 
+        const openUrls = async (targets: string[]): Promise<void> => {
+          const currentDirectory = browser?.model.path ?? '';
+
+          if (uploadDirectory && browser) {
+            await ensureDirectory(uploadDirectory);
+            await browser.model.cd(uploadDirectory);
+          }
+
+          try {
+            for (const url of targets) {
+              await fetchAndOpen(url);
+            }
+          } finally {
+            if (uploadDirectory && browser) {
+              await browser.model.cd(currentDirectory);
+              void browser.model.refresh();
+            }
+          }
+        };
+
         const [match] = matches;
         // handle opening the URL with the Notebook 7 separately
         if (match?.includes('/notebooks') || match?.includes('/edit')) {
           const [first] = urls;
-          await fetchAndOpen(first);
+          await openUrls([first]);
           handleRoute();
           return;
         }
 
         app.restored.then(async () => {
-          await Promise.all(urls.map(url => fetchAndOpen(url)));
+          await openUrls(urls);
           handleRoute();
         });
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,7 +47,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
         const urlParams = new URLSearchParams(search);
         const paramName = 'fromURL';
-        const folderParamName = 'folder';
+        const folderParamName = 'fromURLToFolder';
         const paths = urlParams.getAll(paramName);
         if (paths.length === 0) {
           return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
             ? ''
             : folderPath
           : '';
+        const folderSegments = uploadDirectory.split('/').filter(Boolean);
+        const hasParentDirectorySegment = folderSegments.some(
+          part => part === '..'
+        );
+        const isAbsoluteFolderPath = trimmedFolder.startsWith('/');
 
         // handle the route and remove the fromURL parameter
         const handleRoute = () => {
@@ -157,36 +162,72 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
         const openUrls = async (targets: string[]): Promise<void> => {
           const currentDirectory = browser?.model.path ?? '';
-
-          if (uploadDirectory && browser) {
-            await ensureDirectory(uploadDirectory);
-            await browser.model.cd(uploadDirectory);
-          }
+          let changedDirectory = false;
 
           try {
+            if (uploadDirectory && browser) {
+              await ensureDirectory(uploadDirectory);
+              await browser.model.cd(uploadDirectory);
+              changedDirectory = true;
+            }
+
             for (const url of targets) {
               await fetchAndOpen(url);
             }
+          } catch (error) {
+            return showErrorMessage(
+              trans._p('showErrorMessage', 'Upload Error'),
+              error as Error
+            );
           } finally {
-            if (uploadDirectory && browser) {
-              await browser.model.cd(currentDirectory);
-              void browser.model.refresh();
+            if (changedDirectory && browser) {
+              try {
+                await browser.model.cd(currentDirectory);
+              } catch (reason) {
+                void showErrorMessage(
+                  trans._p('showErrorMessage', 'Upload Error'),
+                  reason as Error
+                );
+              } finally {
+                void browser.model.refresh();
+              }
             }
           }
         };
+
+        if (
+          trimmedFolder &&
+          (isAbsoluteFolderPath || hasParentDirectorySegment)
+        ) {
+          await showErrorMessage(
+            trans.__('Invalid folder path'),
+            trans.__(
+              'The "%1" parameter must be a relative folder path and cannot contain ".." segments.',
+              folderParamName
+            )
+          );
+          handleRoute();
+          return;
+        }
 
         const [match] = matches;
         // handle opening the URL with the Notebook 7 separately
         if (match?.includes('/notebooks') || match?.includes('/edit')) {
           const [first] = urls;
-          await openUrls([first]);
-          handleRoute();
+          try {
+            await openUrls([first]);
+          } finally {
+            handleRoute();
+          }
           return;
         }
 
         app.restored.then(async () => {
-          await openUrls(urls);
-          handleRoute();
+          try {
+            await openUrls(urls);
+          } finally {
+            handleRoute();
+          }
         });
       }
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           const contents = app.serviceManager.contents;
           let currentPath = '';
           for (const part of directory.split('/').filter(Boolean)) {
+            const parentPath = currentPath;
             currentPath = currentPath ? PathExt.join(currentPath, part) : part;
             try {
               const model = await contents.get(currentPath, { content: false });
@@ -108,8 +109,20 @@ const plugin: JupyterFrontEndPlugin<void> = {
                 });
               } catch (saveReason) {
                 const saveError = saveReason as any;
-                if (saveError?.response?.status !== 409) {
-                  throw saveReason;
+                if (saveError?.response?.status === 409) {
+                  continue;
+                }
+                const created = await contents.newUntitled({
+                  path: parentPath,
+                  type: 'directory'
+                });
+                try {
+                  await contents.rename(created.path, currentPath);
+                } catch (renameReason) {
+                  const renameError = renameReason as any;
+                  if (renameError?.response?.status !== 409) {
+                    throw renameReason;
+                  }
                 }
               }
             }
@@ -167,6 +180,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
           try {
             if (uploadDirectory && browser) {
               await ensureDirectory(uploadDirectory);
+              await browser.model.refresh();
               await browser.model.cd(uploadDirectory);
               changedDirectory = true;
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,23 +53,16 @@ const plugin: JupyterFrontEndPlugin<void> = {
           return;
         }
         const urls = paths;
-        const folder = urlParams.get(folderParamName) ?? '';
-        const normalizedFolder = folder ? PathExt.normalize(folder) : '';
-        const trimmedFolder =
-          normalizedFolder !== '/' && normalizedFolder.endsWith('/')
-            ? normalizedFolder.slice(0, -1)
-            : normalizedFolder;
-        const folderPath = PathExt.removeSlash(trimmedFolder);
-        const uploadDirectory = normalizedFolder
-          ? folderPath === '.'
-            ? ''
-            : folderPath
+        const folder = (urlParams.get(folderParamName) ?? '').trim();
+        const normalizedFolder = folder
+          ? PathExt.removeSlash(PathExt.normalize(folder))
           : '';
+        const uploadDirectory =
+          normalizedFolder === '.' ? '' : normalizedFolder;
         const folderSegments = uploadDirectory.split('/').filter(Boolean);
         const hasParentDirectorySegment = folderSegments.some(
           part => part === '..'
         );
-        const isAbsoluteFolderPath = trimmedFolder.startsWith('/');
 
         // handle the route and remove the fromURL parameter
         const handleRoute = () => {
@@ -81,16 +74,28 @@ const plugin: JupyterFrontEndPlugin<void> = {
           router.navigate(`${pathname}${search}`, { skipRouting: true });
         };
 
-        const ensureDirectory = async (directory: string): Promise<void> => {
+        const ensureDirectory = async (
+          directory: string,
+          basePath = ''
+        ): Promise<void> => {
           if (!directory) {
             return;
           }
 
-          const contents = app.serviceManager.contents;
-          let currentPath = '';
+          const isNotFoundError = (reason: any): boolean => {
+            const message = String(reason?.message ?? reason);
+            return (
+              reason?.response?.status === 404 ||
+              message.includes('Could not find content with path')
+            );
+          };
+
+          const contents =
+            browser?.model.manager.services.contents ??
+            app.serviceManager.contents;
+          let currentPath = basePath;
           for (const part of directory.split('/').filter(Boolean)) {
-            const parentPath = currentPath;
-            currentPath = currentPath ? PathExt.join(currentPath, part) : part;
+            currentPath = contents.resolvePath(currentPath, part);
             try {
               const model = await contents.get(currentPath, { content: false });
               if (model.type !== 'directory') {
@@ -99,8 +104,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
                 );
               }
             } catch (reason) {
-              const error = reason as any;
-              if (error?.response?.status !== 404) {
+              if (!isNotFoundError(reason)) {
                 throw reason;
               }
               try {
@@ -108,22 +112,17 @@ const plugin: JupyterFrontEndPlugin<void> = {
                   type: 'directory'
                 });
               } catch (saveReason) {
-                const saveError = saveReason as any;
-                if (saveError?.response?.status === 409) {
+                const message = String(
+                  (saveReason as any)?.message ?? saveReason
+                ).toLowerCase();
+                if (
+                  (saveReason as any)?.response?.status === 409 ||
+                  message.includes('already exists')
+                ) {
+                  // Race with another creator, treat as success.
                   continue;
                 }
-                const created = await contents.newUntitled({
-                  path: parentPath,
-                  type: 'directory'
-                });
-                try {
-                  await contents.rename(created.path, currentPath);
-                } catch (renameReason) {
-                  const renameError = renameReason as any;
-                  if (renameError?.response?.status !== 409) {
-                    throw renameReason;
-                  }
-                }
+                throw saveReason;
               }
             }
           }
@@ -179,9 +178,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
           try {
             if (uploadDirectory && browser) {
-              await ensureDirectory(uploadDirectory);
+              const contents = browser.model.manager.services.contents;
+              await ensureDirectory(uploadDirectory, currentDirectory);
               await browser.model.refresh();
-              await browser.model.cd(uploadDirectory);
+              const targetDirectory = contents.resolvePath(
+                currentDirectory,
+                uploadDirectory
+              );
+              await browser.model.cd(targetDirectory);
               changedDirectory = true;
             }
 
@@ -209,14 +213,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
           }
         };
 
-        if (
-          trimmedFolder &&
-          (isAbsoluteFolderPath || hasParentDirectorySegment)
-        ) {
+        if (normalizedFolder && hasParentDirectorySegment) {
           await showErrorMessage(
             trans.__('Invalid folder path'),
             trans.__(
-              'The "%1" parameter must be a relative folder path and cannot contain ".." segments.',
+              'The "%1" parameter cannot contain ".." segments.',
               folderParamName
             )
           );


### PR DESCRIPTION
Closes #28 

This PR adds a `fromURLToFolder` query parameter to control where files opened via fromURL are created. When folder is provided, the extension creates missing directories, uploads all requested files into that folder in order, opens them, and restores the previous file-browser directory afterward. It also removes handled query params (fromURL and fromURLToFolder) from the URL after processing and updates the README with the new usage.